### PR TITLE
(fix): validate user when form setting is enabled

### DIFF
--- a/src/gravityforms/class-gravityforms.php
+++ b/src/gravityforms/class-gravityforms.php
@@ -105,7 +105,7 @@ class Gravityforms {
 		}
 
 		$form = \GFAPI::get_form( $form_id );
-		if ( '1' !== $form['owc-klantinteractie-enabled'] ) {
+		if ( ! isset( $form['owc-klantinteractie-enabled'] ) || '1' !== $form['owc-klantinteractie-enabled'] ) {
 			return;
 		}
 
@@ -190,7 +190,7 @@ class Gravityforms {
 			return;
 		}
 
-		if ( '1' !== $form['owc-klantinteractie-enabled'] ) {
+		if ( ! isset( $form['owc-klantinteractie-enabled'] ) || '1' !== $form['owc-klantinteractie-enabled'] ) {
 			return;
 		}
 
@@ -222,6 +222,10 @@ class Gravityforms {
 	 * @return array The form.
 	 */
 	public function validate_user( $form ) {
+		if ( ! isset( $form['owc-klantinteractie-enabled'] ) || '1' !== $form['owc-klantinteractie-enabled'] ) {
+			return $form;
+		}
+
 		$user_data = Klantinteractie_API::get_instance()->get_user_data();
 		if ( ! empty( $user_data['results'] ) ) {
 			return $form;


### PR DESCRIPTION
Ondanks dat de formulier instelling uitstaat wordt de code wel uitgevoerd waardoor het DigiD veld omviel. De API credentials zijn niet ingevuld nog vandaar dat de fout naar voren kwam. Wellicht hebben jullie hier iets aan.


<img width="823" alt="Scherm­afbeelding 2024-06-21 om 14 36 51" src="https://github.com/OpenWebconcept/plugin-klantinteractie/assets/11852816/1e0e5880-e888-4a84-9eaf-1dc6168bccde">
